### PR TITLE
Convert Test Dates to UTC

### DIFF
--- a/lib/createReduxMiddleware/createReduxMiddleware.test.js
+++ b/lib/createReduxMiddleware/createReduxMiddleware.test.js
@@ -152,14 +152,14 @@ describe('redux', function () {
     });
 
     it('date', function () {
-      const v = new Date('2000-01-02 03:04:05.678');
+      const v = new Date('2000-01-02T03:04:05.678Z');
 
       const s = storeValue(v);
 
       s.should.deep.equal({
         serifyKey: null,
         type: 'Date',
-        value: 946753445678,
+        value: 946782245678,
       });
     });
 
@@ -247,7 +247,7 @@ describe('redux', function () {
             ],
           ],
           [
-            { serifyKey: null, type: 'Date', value: 946753445678 },
+            { serifyKey: null, type: 'Date', value: 946778645678 },
             [
               { serifyKey: null, type: 'Set', value: ['d', 5, 'f'] },
               {

--- a/lib/serify/serify.test.js
+++ b/lib/serify/serify.test.js
@@ -121,7 +121,7 @@ describe('serify', function () {
     });
 
     it('date', function () {
-      const v = new Date('2000-01-02 03:04:05.678');
+      const v = new Date('2000-01-02T03:04:05.678Z');
 
       const s = serify(v);
       // console.log(s);
@@ -129,7 +129,7 @@ describe('serify', function () {
       s.should.deep.equal({
         serifyKey: null,
         type: 'Date',
-        value: 946753445678,
+        value: 946782245678,
       });
     });
 
@@ -181,7 +181,7 @@ describe('serify', function () {
           ],
         ],
         [
-          new Date('2000-01-02 03:04:05.678'),
+          new Date('2000-01-02T03:04:05.678Z'),
           [
             new Set(['d', 5, 'f']),
             new Map([
@@ -219,7 +219,7 @@ describe('serify', function () {
             ],
           ],
           [
-            { serifyKey: null, type: 'Date', value: 946753445678 },
+            { serifyKey: null, type: 'Date', value: 946782245678 },
             [
               { serifyKey: null, type: 'Set', value: ['d', 5, 'f'] },
               {


### PR DESCRIPTION
Some of the date strings within the test suite do not have the explicit `Z` suffix for UTC, so the date they represent changes based on the environment's timezone, which causes test failures on timezones other than the ones their corresponding timestamps were hard-coded in. This PR updates all dates throughout the test suite to use UTC.