### PR TITLE
Proposal: Support Overriding Object Serify Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ for a fully worked out example using the Redux middleware.
 <dt><a href="#deserifierCallback">deserifierCallback</a> ⇒ <code>*</code></dt>
 <dd><p>callback to deserify a custom type.</p>
 </dd>
+<dt><a href="#serifyKey">serifyKey</a> ⇒ <code>symbol</code></dt>
+<dd><p>static property name to override an object's serify key</p>
+</dd>
 <dt><a href="#OptionsType">OptionsType</a> : <code>Object</code></dt>
 <dd><p>serify-deserify options type</p>
 </dd>
@@ -190,6 +193,13 @@ callback to deserify a custom type.
 | Param | Type | Description |
 | --- | --- | --- |
 | value | <code>\*</code> | serified value |
+
+<a name="serifyKey"></a>
+
+## serifyKey => <code>symbol</code>
+static property name to override an object's serify key
+
+**Kind**: symbol
 
 <a name="OptionsType"></a>
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ for a fully worked out example using the Redux middleware.
 
 # API Documentation
 
+## Constants
+
+<dl>
+<dt><a href="#serifyKey">serifyKey</a></dt>
+<dd><p>static property name to override an object&#39;s serify key</p>
+</dd>
+</dl>
+
 ## Functions
 
 <dl>
@@ -118,9 +126,6 @@ for a fully worked out example using the Redux middleware.
 <dt><a href="#deserifierCallback">deserifierCallback</a> ⇒ <code>*</code></dt>
 <dd><p>callback to deserify a custom type.</p>
 </dd>
-<dt><a href="#serifyKey">serifyKey</a> ⇒ <code>symbol</code></dt>
-<dd><p>static property name to override an object's serify key</p>
-</dd>
 <dt><a href="#OptionsType">OptionsType</a> : <code>Object</code></dt>
 <dd><p>serify-deserify options type</p>
 </dd>
@@ -132,6 +137,12 @@ for a fully worked out example using the Redux middleware.
 </dd>
 </dl>
 
+<a name="serifyKey"></a>
+
+## serifyKey
+static property name to override an object's serify key
+
+**Kind**: global constant  
 <a name="createReduxMiddleware"></a>
 
 ## createReduxMiddleware([options]) ⇒ <code>function</code>
@@ -193,13 +204,6 @@ callback to deserify a custom type.
 | Param | Type | Description |
 | --- | --- | --- |
 | value | <code>\*</code> | serified value |
-
-<a name="serifyKey"></a>
-
-## serifyKey => <code>symbol</code>
-static property name to override an object's serify key
-
-**Kind**: symbol
 
 <a name="OptionsType"></a>
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,3 @@
-export { serify } from './serify/serify.js';
+export { serify, serifyKey } from './serify/serify.js';
 export { deserify } from './deserify/deserify.js';
 export { createReduxMiddleware } from './createReduxMiddleware/createReduxMiddleware.js';

--- a/lib/serify/serify.js
+++ b/lib/serify/serify.js
@@ -4,6 +4,9 @@ import { mergeOptions } from '../options/mergeOptions.js';
 
 import '../options/types.js';
 
+/**
+ * static property name to override an object's serify key
+ */
 export const serifyKey = Symbol('serifyKey');
 
 /**

--- a/lib/serify/serify.js
+++ b/lib/serify/serify.js
@@ -4,6 +4,8 @@ import { mergeOptions } from '../options/mergeOptions.js';
 
 import '../options/types.js';
 
+export const serifyKey = Symbol('serifyKey');
+
 /**
  * serify a node
  *
@@ -18,7 +20,7 @@ import '../options/types.js';
 const serifyNode = (value, options) => {
   if (isPrimitive(value) || value.serifyKey === options.serifyKey) return value;
 
-  const valueType = value.constructor?.name;
+  const valueType = value.constructor?.[serifyKey] ?? value.constructor?.name;
   const serifyType = options.types[valueType];
 
   if (serifyType) {

--- a/lib/serify/serify.test.js
+++ b/lib/serify/serify.test.js
@@ -5,12 +5,18 @@ const should = chai.should();
 
 import { serify } from './serify.js';
 import { Custom, getCustomOptions } from '../test/Custom.js';
+import {
+  CustomWithKey,
+  getCustomWithKeyOptions,
+} from '../test/CustomWithKey.js';
 
 let customOptions;
+let customWithKeyOptions;
 
 describe('serify', function () {
   beforeEach(function () {
     customOptions = getCustomOptions();
+    customWithKeyOptions = getCustomWithKeyOptions();
   });
 
   describe('serializable', function () {
@@ -243,6 +249,14 @@ describe('serify', function () {
       const s = serify(v, customOptions);
 
       s.should.deep.equal({ serifyKey: null, type: 'Custom', value: 42 });
+    });
+
+    it('custom with key', function () {
+      const v = new CustomWithKey(42);
+
+      const s = serify(v, customWithKeyOptions);
+
+      s.should.deep.equal({ serifyKey: null, type: 'AlternateKey', value: 42 });
     });
   });
 

--- a/lib/test/CustomWithKey.js
+++ b/lib/test/CustomWithKey.js
@@ -1,0 +1,18 @@
+import { serifyKey } from '../serify/serify.js';
+
+export class CustomWithKey {
+  static [serifyKey] = 'AlternateKey';
+
+  constructor(p) {
+    this.p = p;
+  }
+}
+
+export const getCustomWithKeyOptions = () => ({
+  types: {
+    AlternateKey: {
+      serifier: (u) => u.p,
+      deserifier: (s) => new CustomWithKey(s),
+    },
+  },
+});


### PR DESCRIPTION
In minified outputs with name mangling enabled this library's use of `constructor.name` can cause issues as the class names change during minification and between builds, and even without that issue it's impossible to register two classes with the same name.

This proposal allows optionally setting an explicit value for the library to use for an object's serify key instead of `constructor.name` through a new exported symbol `serifyKey`.

It can be used as follows:

```js
import { serifyKey } from '@karmaniverous/serify-deserify';

class CustomClass {
   static [serifyKey] = 'AlternateKey';
}

// ...

serify(data, {
  types: { AlternateKey: ... },
});
```